### PR TITLE
Evidence slider controls and Nightmare logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,52 +254,59 @@
 			<span></span>
 			<div id="evidence">
 				<h2 class="minimal">Confirmed Evidence:</h2>
-				<p class="instructions">Check off found evidence here. Evidence not necessary based on previously selected evidence will be eliminated. Click twice on evidence to "eliminate" it from possibilities. </p>
-				<ul>
-					<li>
-						<div>
-							<input type="checkbox" class="indeterminate" id="dots" />
-							<label for="dots">D.O.T.S Projector</label>
-						</div>
-					</li>
-					<li>
-						<div>
-							<input type="checkbox" class="indeterminate" id="emf" />
-							<label for="emf">EMF Level 5</label>
-						</div>
-					</li>
-					<li>
-						<div>
-							<input type="checkbox" class="indeterminate" id="fingerprints" />
-							<label for="fingerprints">Fingerprints</label>
-						</div>
-					</li>
-					<li>
-						<div>
-							<input type="checkbox" class="indeterminate" id="freezing" />
-							<label for="freezing">Freezing Temperatures</label>
-						</div>
-					</li>
-					<li>
-						<div>
-							<input type="checkbox" class="indeterminate" id="orb" />
-							<label for="orb">Ghost Orb</label>
-						</div>
-					</li>
-					<li>
-						<div>
-							<input type="checkbox" class="indeterminate" id="writing" />
-							<label for="writing">Ghost Writing</label>
-						</div>
-					</li>
-					<li>
-						<div>
-							<input type="checkbox" class="indeterminate" id="box" />
-							<label for="box">Spirit Box</label>
-						</div>
-					</li>
-					
-				</ul>
+				<p class="instructions">Track found evidence here. Slide left for confirmed evidence and right for eliminated evidence. If you are playing on Nightmare difficulty select Nightmare to account for one piece of evidence being hidden.  </p>
+				<div id="nightmare_checkbox">
+					<input  id="nightmare_difficulty" type="checkbox"  name="nightmare_difficulty" />
+					<label for="nightmare_difficulty">Nightmare</label>
+				</div>
+
+				<div id="evidence_list">
+					<ul>
+						<li>
+							<div class="evidenceToggle">
+								<label for="dots">D.O.T.S Projector</label>
+								<input type="range" name="dots" id="dots" min="0" max="2" />
+							</div>
+						</li>
+						<li>
+							<div class="evidenceToggle">
+								<label for="emf">EMF Level 5</label>
+								<input type="range" name="emf" id="emf" min="0" max="2" />
+							</div>
+						</li>
+						<li>
+							<div class="evidenceToggle">
+								<label for="fingerprints">Fingerprints</label>
+								<input type="range" name="fingerprints" id="fingerprints" min="0" max="2" />
+							</div>
+						</li>
+						<li>
+							<div class="evidenceToggle">
+								<label for="freezing">Freezing Temperatures</label>
+								<input type="range" name="freezing" id="freezing" min="0" max="2" />
+							</div>
+						</li>
+						<li>
+							<div class="evidenceToggle">
+								<label for="orb">Ghost Orb</label>
+								<input type="range" name="orb" id="orb" min="0" max="2" />
+							</div>
+						</li>
+						<li>
+							<div class="evidenceToggle">
+								<label for="writing">Ghost Writing</label>
+								<input type="range" name="writing" id="writing" min="0" max="2" />
+							</div>
+						</li>
+						<li>
+							<div class="evidenceToggle">
+								<label for="box">Spirit Box</label>
+								<input type="range" name="box" id="box" min="0" max="2" />
+							</div>
+						</li>
+
+					</ul>
+				</div>
 			</div><!-- checkboxes -->
 		</form>
 		<div class="warning">
@@ -382,7 +389,7 @@
 					<ul class="evidence">
 						<li data-evidence="emf">EMF Level 5</li>
 						<li data-evidence="fingerprints">Fingerprints</li>
-						<li data-evidence="dots">D.O.T.S Projector</li>
+						<li data-evidence="dots" required="true">D.O.T.S Projector</li>
 					</ul>
 				</div>
 			</div><!-- ghost -->
@@ -410,7 +417,7 @@
 					<ul class="evidence">
 						<li data-evidence="fingerprints">Fingerprints</li>
 						<li data-evidence="orb">Ghost Orb</li>
-						<li data-evidence="freezing">Freezing Temperatures</li>
+						<li data-evidence="freezing" required="true">Freezing Temperatures</li>
 					</ul>
 				</div>
 			</div><!-- ghost -->
@@ -486,7 +493,7 @@
 						<li data-evidence="box">Spirit Box</li>
 						<li data-evidence="fingerprints">Fingerprints</li>
 						<li data-evidence="freezing">Freezing Temperatures</li>
-						<li data-evidence="orb">Ghost Orb</li>
+						<li data-evidence="orb" required="true">Ghost Orb</li>
 					</ul>
 				</div>
 			</div><!-- ghost -->
@@ -533,7 +540,7 @@
 					</div>
 					<ul class="evidence">
 						<li data-evidence="emf">EMF Level 5</li>
-						<li data-evidence="fingerprints">Fingerprints</li>
+						<li data-evidence="fingerprints" required="true">Fingerprints</li>
 						<li data-evidence="orb">Ghost Orb</li>
 					</ul>
 				</div>

--- a/main.css
+++ b/main.css
@@ -157,7 +157,7 @@ input[type="text"] {
 	margin: 0 10px 0 0;
 }
 
-input[type="text"]:focus {	
+input[type="text"]:focus {
 	background: #fff;
 	color: #000;
 }
@@ -269,15 +269,6 @@ input[type="checkbox"] + label {
 	text-decoration: none;
 }
 
-input[type="checkbox"].indeterminate + label {
-	background: #1a1a1a;
-	text-decoration: line-through;
-}
-input[type="checkbox"].indeterminate:indeterminate + label {
-	background: #484848;
-	text-decoration: none;
-}
-
 input[type="checkbox"]:checked + label {
 	background: #f41f86;
 	text-decoration: none;
@@ -302,20 +293,56 @@ input[type="checkbox"]:checked + label {
 	margin: 0 0 5px 0;
 }
 
+#evidence #nightmare_checkbox {
+	width: 10em;
+	margin: 0 0 5px 0;
+}
+
 #evidence p {
 	margin: 0 0 15px 0;
 }
 
-#evidence li {
+#evidence_list li {
 	list-style: none;
+	white-space: nowrap;
+	width: auto;
 }
 
-#evidence ul li.disabled {
+#evidence_list ul li.disabled {
 	display: none;
 }
 
-#evidence input[type="checkbox"].no + label {
+#evidence_list input[type="checkbox"].no + label {
 	background: #971a1a;
+}
+
+.evidenceToggle input[type="range"] {
+	appearance: none;
+	width: 150px;
+	padding: 1px;
+	border-radius: 2px;
+	background-color: #484848;
+}
+
+.evidenceToggle input[type="range"]::-webkit-slider-thumb  {
+	appearance: none;
+	height: 30px;
+	width: 45px;
+	border-radius: 2px;
+	background-color: #2f2f2f;
+}
+
+.evidenceToggle input[type="range"].yes::-webkit-slider-thumb  {
+	background-color: #f41f86;
+}
+
+.evidenceToggle input[type="range"].no::-webkit-slider-thumb  {
+	background-color: #971a1a;
+}
+
+.evidenceToggle label  {
+	margin: auto;
+	display: block;
 }
 
 #ghosts {

--- a/main.js
+++ b/main.js
@@ -75,8 +75,94 @@ function reset() {
 	$('form').trigger("reset");
 	//$("#aggression_list input").prop("checked", false).trigger("change");
 	$("#possessions_list input").prop("checked", false).trigger("change");
-	$(".indeterminate").prop("checked", true).prop("indeterminate", true).prop("readonly", true);
+	$('#evidence input').val(1);
 	warning("Please select up to 3 pieces of evidence to narrow down the spookster.", "#2f2f2f", "#fff");
+}
+
+function updateGhosts() {
+	var foundEvidence = $('#evidence input').filter(function() { return this.value == 0 }).map(function(){return this.id;}).get();
+	var nightmare = $('#nightmare_difficulty').prop("checked");
+	var minEvidenceLeft = Number.MAX_SAFE_INTEGER;
+	var maxEvidenceLeft = 0;
+
+	/**
+	*	Check the evidence list of each ghost
+	* Hide any ghosts that do not contain all currently discovered evidence
+	* Fade any ghosts that can be ruled out based on excluded evidence
+	*/
+	$(".evidence").each(function() {
+		$(this).parents(".ghost").removeClass("excluded");
+		if($(this).children(".yes").length !== foundEvidence.length) {
+			fadeout($(this).parents(".ghost"));
+		} else if($(this).children(".no").length > (nightmare ? 1 : 0) || $(this).find(".no[required='true']").length > 0 ) {
+			// In nightmare difficulty one piece of evidence is hidden, so a ghost can only be ruled out if
+			// two pieces of evidence are excluded OR if a required piece of evidence is excluded
+			$(this).parents(".ghost").addClass("excluded");
+			fadein($(this).parents(".ghost"));
+		}	else {
+			var thisEvidenceLeft = $(this).children("li:not(.yes)");
+			if(thisEvidenceLeft.length < minEvidenceLeft) {
+				minEvidenceLeft = thisEvidenceLeft.length;
+			} else if(thisEvidenceLeft.length > maxEvidenceLeft) {
+				maxEvidenceLeft = thisEvidenceLeft.length;
+			}
+			fadein($(this).parents(".ghost"));
+		}
+	});
+
+	var validEvidence = $(".ghost:not(.disabled):not(.excluded) .evidence li:not(.yes)").map(function(){return $(this).data("evidence");}).get()
+		.filter(function(value, index, self) {
+		return self.indexOf(value) === index;
+	});
+
+	var validableEvidence = $(".ghost:not(.disabled).excluded .evidence li.no").map(function(){return $(this).data("evidence");}).get()
+		.filter(function(value, index, self) {
+		return self.indexOf(value) === index && validEvidence.indexOf(value) === -1;
+	});
+
+
+	$('#evidence_list input').filter(function() { return this.value != 0 }).each(function() {
+		if(validEvidence.includes($(this).attr("id")))
+			$(this).parents('li').removeClass('disabled');
+		else if(validableEvidence.includes($(this).attr("id")))
+			$(this).parents('li').removeClass('disabled');
+		else
+			$(this).parents('li').addClass('disabled');
+	});
+
+	if(maxEvidenceLeft >= 1)
+	{
+		if(minEvidenceLeft === maxEvidenceLeft)
+		{
+			if(maxEvidenceLeft === 1)
+				warning("Please select another evidence to identify the spookster.", "#2f2f2f", "#fff");
+			else
+				warning("Please select up to " + maxEvidenceLeft + " pieces of evidence to narrow down the spookster. Click it again to eliminate it as a possibility.", "#2f2f2f", "#fff");
+		}
+		else
+		{
+			// Technically the if/else statements don't need to be as complex...
+			warning("Please select up to " + maxEvidenceLeft + " pieces of evidence to narrow down the spookster. Click it again to eliminate it as a possibility.", "#2f2f2f", "#fff");
+		}
+	}
+	else if($(".ghost:not(.excluded):not(.disabled)").length === 1)
+	{
+		var Ghost = $(".ghost:not(.excluded):not(.disabled)");
+		if($(".ghost.excluded").length > 0)
+		{
+			Ghost.addClass("maybe");
+			warning("A ghost! But how can you be so sure?", "#1faef4", "#000");
+		}
+		else
+		{
+			Ghost.addClass("yes");
+			warning("Oh shit, a ghooost! Click the reset button above to start over.", "#55be61", "#000");
+		}
+	}
+	else if($(".ghost.excluded").length > 0)
+		warning("You excluded a vital piece of evidence!", "#c61c1ce0", "#fff");
+	else
+		warning("No combination of evidence works!", "#c61c1ce0", "#fff");
 }
 
 $("#toggle_instructions").click(function(){
@@ -192,34 +278,34 @@ $("#possessions_list input").change(function() {
 	$("#possessions_hints").children(`#${textToRevealID}`).removeClass("hidden");
 });
 
-$("#evidence input").change(function() {
-	if(this.readOnly) {
-		this.readOnly = false;
-		this.checked = true;
-		this.indeterminate = false;
-	}
-	else if(this.checked) {
-		this.readOnly = true;
-		this.indeterminate = true;
-	}
-	
-	var foundEvidence = $('#evidence input[type="checkbox"]:not(:indeterminate):checked').map(function(){return this.id;}).get();
+$("#nightmare_difficulty").change(function() {
+	updateGhosts();
+});
 
+
+//Evidence has changed, update all affected ghosts
+$("#evidence_list input").change(function() {
 	{
 		var changedEvidence = $(this).attr("id");
 		var changedGhosts = $("ul.evidence > li").filter(function(){
 			return $(this).data("evidence") === changedEvidence;
 		});
-		if(this.indeterminate) {
+
+		if(this.value == 1) {
+			$(this).removeClass("yes no");
 			changedGhosts.each(function() {
 				$(this).removeClass("yes no");
 			});
-		} else if(this.checked) {
+		} else if(this.value == 0) {
+			$(this).removeClass("no");
+			$(this).addClass("yes");
 			changedGhosts.each(function() {
 				$(this).removeClass("no");
 				$(this).addClass("yes");
 			})
-		} else {
+		} else if(this.value == 2) {
+			$(this).removeClass("yes");
+			$(this).addClass("no");
 			changedGhosts.each(function() {
 				$(this).removeClass("yes");
 				$(this).addClass("no");
@@ -227,80 +313,7 @@ $("#evidence input").change(function() {
 		}
 	}
 
-	var minEvidenceLeft = Number.MAX_SAFE_INTEGER;
-	var maxEvidenceLeft = 0;
-
-	$(".evidence").each(function() {
-		$(this).parents(".ghost").removeClass("excluded");
-		if($(this).children(".yes").length !== foundEvidence.length)
-			fadeout($(this).parents(".ghost"));
-		else if($(this).children(".no").length > 0) {
-			$(this).parents(".ghost").addClass("excluded");
-			fadein($(this).parents(".ghost"));
-		}
-		else {
-			var thisEvidenceLeft = $(this).children("li:not(.yes)");
-			if(thisEvidenceLeft.length < minEvidenceLeft)
-				minEvidenceLeft = thisEvidenceLeft.length;
-			else if(thisEvidenceLeft.length > maxEvidenceLeft)
-				maxEvidenceLeft = thisEvidenceLeft.length;
-			fadein($(this).parents(".ghost"));
-		}
-	});
-
-
-	var validEvidence = $(".ghost:not(.disabled):not(.excluded) .evidence li:not(.yes)").map(function(){return $(this).data("evidence");}).get()
-		.filter(function(value, index, self) {
-		return self.indexOf(value) === index;
-	});
-
-	var validableEvidence = $(".ghost:not(.disabled).excluded .evidence li.no").map(function(){return $(this).data("evidence");}).get()
-		.filter(function(value, index, self) {
-		return self.indexOf(value) === index && validEvidence.indexOf(value) === -1;
-	});
-
-	$('#evidence input[type="checkbox"]:indeterminate, #evidence input[type="checkbox"]:not(:checked)').each(function() {
-		if(validEvidence.includes($(this).attr("id")))
-			$(this).parents('li').removeClass('disabled');
-		else if(validableEvidence.includes($(this).attr("id")))
-			$(this).parents('li').removeClass('disabled');
-		else
-			$(this).parents('li').addClass('disabled');
-	});
-
-	if(maxEvidenceLeft >= 1)
-	{
-		if(minEvidenceLeft === maxEvidenceLeft)
-		{
-			if(maxEvidenceLeft === 1)
-				warning("Please select another evidence to identify the spookster.", "#2f2f2f", "#fff");
-			else
-				warning("Please select up to " + maxEvidenceLeft + " pieces of evidence to narrow down the spookster. Click it again to eliminate it as a possibility.", "#2f2f2f", "#fff");
-		}
-		else
-		{
-			// Technically the if/else statements don't need to be as complex...
-			warning("Please select up to " + maxEvidenceLeft + " pieces of evidence to narrow down the spookster. Click it again to eliminate it as a possibility.", "#2f2f2f", "#fff");
-		}
-	}
-	else if($(".ghost:not(.excluded):not(.disabled)").length === 1)
-	{
-		var Ghost = $(".ghost:not(.excluded):not(.disabled)");
-		if($(".ghost.excluded").length > 0)
-		{
-			Ghost.addClass("maybe");
-			warning("A ghost! But how can you be so sure?", "#1faef4", "#000");
-		}
-		else
-		{
-			Ghost.addClass("yes");
-			warning("Oh shit, a ghooost! Click the reset button above to start over.", "#55be61", "#000");
-		}
-	}
-	else if($(".ghost.excluded").length > 0)
-		warning("You excluded a vital piece of evidence!", "#c61c1ce0", "#fff");
-	else
-		warning("No combination of evidence works!", "#c61c1ce0", "#fff");
+	updateGhosts();
 });
 
 $(document).ready(reset);


### PR DESCRIPTION
+Converted evidence checkboxes to range sliders for easier input. Attempted to match style as best as possible.

+Added Nightmare toggle to account for one piece of evidence being hidden in nightmare difficulty. While enabled ghosts will only be hidden if at least two of their evidences are eliminated or if a guaranteed evidence is eliminated.