### PR TITLE
Fix maxEvidenceLeft calculation

### DIFF
--- a/main.js
+++ b/main.js
@@ -103,7 +103,8 @@ function updateGhosts() {
 			var thisEvidenceLeft = $(this).children("li:not(.yes)");
 			if(thisEvidenceLeft.length < minEvidenceLeft) {
 				minEvidenceLeft = thisEvidenceLeft.length;
-			} else if(thisEvidenceLeft.length > maxEvidenceLeft) {
+			}
+			if(thisEvidenceLeft.length > maxEvidenceLeft) {
 				maxEvidenceLeft = thisEvidenceLeft.length;
 			}
 			fadein($(this).parents(".ghost"));


### PR DESCRIPTION
Fix corner case where warnings were being incorrectly shown when Mimic is the first viable ghost on the list. The correct value for maxEvidenceLeft was not being set.

![mimic_onryo_bug](https://user-images.githubusercontent.com/28550446/156020904-c277fb40-9add-487a-ae44-e581c59a89b0.jpg)
![mimic_onryo_bug2](https://user-images.githubusercontent.com/28550446/156021919-bfe4de6c-5e1d-4881-8a01-75056b9b271a.jpg)

