### PR TITLE
Alphabetically order Deogen, Moroi, and Thaye for consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -396,6 +396,35 @@
 			</div><!-- ghost -->
 			<div class="ghost">
 				<div>
+					<h3>Deogen</h3>
+					<div class="description">
+						<p>Sometimes surrounded by an endless fog, Deogen have been eluding ghost hunters for years. These ghosts have been reported to find even the most hidden prey, before stalking them into exhaustion.</p>
+						<h4>Unique Strengths</h4>
+						<p>Deogen constantly sense the living. You can run but you can't hide.</p>
+						<h4>Weaknesses</h4>
+						<p>Deogen require a lot of energy to form and will move very slowly when approaching its victim.</p>
+						<h4>Unique Features</h4>
+						<ul style="margin-left:15px">
+							<li><font color="orange">Average Sanity Hunt</font> at 40%.</li>
+							<li><font color="tomato">Hunting Speed</font> increased by 75% when more than 6m away. Below 6m, the ghost becomes <b>much</b> slower as it approaches the player.</li>
+							<li><font color="deeppink">When Hunting</font>, it always has line of sight with all players (hiding spots don't work) and will occasionally repick the nearest target throughout the hunt.</li>
+							<li><font color="deeppink">When Hunting</font>, it is invisible for shorter intervals.</li>
+							<li>Will show up more often as a silhouette on the D.O.T.S Projector.</li>
+							<li>Can produce a unique heavy bull-like breathing within 1 meter.</li>
+							<li>Using a Smudge Stick will force it to repick the nearest target when the smudge effect runs out.</li>
+							<li><font color="gold">Nightmare Evidence</font> will always be Spirit Box.</li>
+						</ul>
+						<h4>Evidence</h4>
+					</div>
+					<ul class="evidence">
+						<li data-evidence="box">Spirit Box</li>
+						<li data-evidence="writing">Ghost Writing</li>
+						<li data-evidence="dots">D.O.T.S Projector</li>
+					</ul>
+				</div>
+			</div><!-- ghost -->
+			<div class="ghost">
+				<div>
 					<h3>Goryo</h3>
 					<div class="description">
 						<p>When a Goryo passes through a D.O.T.S Projector, using a video camera is the only way to see it.</p>
@@ -519,6 +548,35 @@
 						<li data-evidence="fingerprints">Fingerprints</li>
 						<li data-evidence="freezing">Freezing Temperatures</li>
 						<li data-evidence="orb" required="true">Ghost Orb</li>
+					</ul>
+				</div>
+			</div><!-- ghost -->
+			<div class="ghost">
+				<div>
+					<h3>Moroi</h3>
+					<div class="description">
+						<p>Moroi have risen from the grave to drain energy from the living. They have been known to place curses on their victims, curable only by antidotes or moving very far away.</p>
+						<h4>Unique Strengths</h4>
+						<p>The weaker their victims, the stronger the Moroi becomes.</p>
+						<h4>Weaknesses</h4>
+						<p>Moroi suffer from hyperosmia, weakening them for longer periods.</p>
+						<h4>Unique Features</h4>
+						<ul style="margin-left:15px">
+							<li><font color="tomato">Hunting Speed</font> is 10% slower above 45% average sanity, gradually increasing to 30% faster at 0% average sanity.</li>
+							<li><font color="tomato">Hunting Speed</font> will continuously accelerate with line of sight.</li>
+							<li><font color="plum">Sanity Loss</font>: Getting a Spirit Box response will curse the player, doubling their passive sanity drain, and standing in a lit area will not stop the sanity drain.</li>
+							<li>The curse will pause when outside of the house, and start again when back inside.</li>
+							<li>Sanity Pills will break the curse.</li>
+							<li>Multiple players can be cursed at the same time.</li>
+							<li>Smudging the Moroi during a hunt will cause it to wander for 12 seconds (instead of 6 seconds).</li>
+							<li><font color="gold">Nightmare Evidence</font> will always be Spirit Box.</li>
+						</ul>
+						<h4>Evidence</h4>
+					</div>
+					<ul class="evidence">
+						<li data-evidence="box">Spirit Box</li>
+						<li data-evidence="freezing">Freezing Temperatures</li>
+						<li data-evidence="writing">Ghost Writing</li>
 					</ul>
 				</div>
 			</div><!-- ghost -->
@@ -773,6 +831,32 @@
 					</ul>
 				</div>
 			</div><!-- ghost -->
+			<div class="ghost">
+				<div>
+					<h3>Thaye</h3>
+					<div class="description">
+						<p>Thaye have been known to rapidly age over time, even in the afterlife. From what we've learned, they seem to deteriorate faster while within the presence of the living.</p>
+						<h4>Unique Strengths</h4>
+						<p>Upon entering the location, Thaye will become active, defensive and agile.</p>
+						<h4>Weaknesses</h4>
+						<p>Thaye will weaken over time, making them weaker, slower and less aggressive.</p>
+						<h4>Unique Features</h4>
+						<ul style="margin-left:15px">
+							<li><font color="orange">Average Sanity Hunt</font> starts at 75%. Decreases each time the ghost ages, stopping at 15%.</li>
+							<li><font color="tomato">Hunting Speed</font> increased by 60% at start. Decreases each time the ghost ages, stopping at 1/3 of the initial speed (slower than players).</li>
+							<li><font color="deepskyblue">Interactions</font> and <font color="aqua">Ghost Events</font> happen very frequently at start. Decreases each time the ghost ages, stopping at 1/4 of the initial frequency.</li>
+							<li>Does not speed up with line of sight of a player.</li>
+							<li>Only ages when a player is in the same room as the ghost.</li>
+						</ul>
+						<h4>Evidence</h4>
+					</div>
+					<ul class="evidence">
+						<li data-evidence="orb">Ghost Orb</li>
+						<li data-evidence="writing">Ghost Writing</li>
+						<li data-evidence="dots">D.O.T.S Projector</li>
+					</ul>
+				</div>
+			</div><!-- ghost -->
             <div class="ghost">
 				<div>
 					<h3>The Twins</h3>
@@ -869,90 +953,6 @@
 					<ul class="evidence">
 						<li data-evidence="orb">Ghost Orb</li>
 						<li data-evidence="freezing">Freezing Temperatures</li>
-						<li data-evidence="dots">D.O.T.S Projector</li>
-					</ul>
-				</div>
-			</div><!-- ghost -->
-			<div class="ghost">
-				<div>
-					<h3>Deogen</h3>
-					<div class="description">
-					<p>Sometimes surrounded by an endless fog, Deogen have been eluding ghost hunters for years. These ghosts have been reported to find even the most hidden prey, before stalking them into exhaustion.</p>
-						<h4>Unique Strengths</h4>
-						<p>Deogen constantly sense the living. You can run but you can't hide.</p>
-						<h4>Weaknesses</h4>
-						<p>Deogen require a lot of energy to form and will move very slowly when approaching its victim.</p>
-						<h4>Unique Features</h4>
-						<ul style="margin-left:15px">
-							<li><font color="orange">Average Sanity Hunt</font> at 40%.</li>
-							<li><font color="tomato">Hunting Speed</font> increased by 75% when more than 6m away. Below 6m, the ghost becomes <b>much</b> slower as it approaches the player.</li>
-							<li><font color="deeppink">When Hunting</font>, it always has line of sight with all players (hiding spots don't work) and will occasionally repick the nearest target throughout the hunt.</li>
-							<li><font color="deeppink">When Hunting</font>, it is invisible for shorter intervals.</li>
-							<li>Will show up more often as a silhouette on the D.O.T.S Projector.</li>
-							<li>Can produce a unique heavy bull-like breathing within 1 meter.</li>
-							<li>Using a Smudge Stick will force it to repick the nearest target when the smudge effect runs out.</li>
-							<li><font color="gold">Nightmare Evidence</font> will always be Spirit Box.</li>
-						</ul>
-						<h4>Evidence</h4>
-					</div>
-					<ul class="evidence">
-						<li data-evidence="box">Spirit Box</li>
-						<li data-evidence="writing">Ghost Writing</li>
-						<li data-evidence="dots">D.O.T.S Projector</li>
-					</ul>
-				</div>
-			</div><!-- ghost -->
-			<div class="ghost">
-				<div>
-					<h3>Moroi</h3>
-					<div class="description">
-					<p>Moroi have risen from the grave to drain energy from the living. They have been known to place curses on their victims, curable only by antidotes or moving very far away.</p>
-						<h4>Unique Strengths</h4>
-						<p>The weaker their victims, the stronger the Moroi becomes.</p>
-						<h4>Weaknesses</h4>
-						<p>Moroi suffer from hyperosmia, weakening them for longer periods.</p>
-						<h4>Unique Features</h4>
-						<ul style="margin-left:15px">
-							<li><font color="tomato">Hunting Speed</font> is 10% slower above 45% average sanity, gradually increasing to 30% faster at 0% average sanity.</li>
-							<li><font color="tomato">Hunting Speed</font> will continuously accelerate with line of sight.</li>
-								<li><font color="plum">Sanity Loss</font>: Getting a Spirit Box response will curse the player, doubling their passive sanity drain, and standing in a lit area will not stop the sanity drain.</li>
-							<li>The curse will pause when outside of the house, and start again when back inside.</li>
-							<li>Sanity Pills will break the curse.</li>
-							<li>Multiple players can be cursed at the same time.</li>
-							<li>Smudging the Moroi during a hunt will cause it to wander for 12 seconds (instead of 6 seconds).</li>
-							<li><font color="gold">Nightmare Evidence</font> will always be Spirit Box.</li>
-						</ul>
-						<h4>Evidence</h4>
-					</div>
-					<ul class="evidence">
-						<li data-evidence="box">Spirit Box</li>
-						<li data-evidence="freezing">Freezing Temperatures</li>
-						<li data-evidence="writing">Ghost Writing</li>
-					</ul>
-				</div>
-			</div><!-- ghost -->
-			<div class="ghost">
-				<div>
-					<h3>Thaye</h3>
-					<div class="description">
-					<p>Thaye have been known to rapidly age over time, even in the afterlife. From what we've learned, they seem to deteriorate faster while within the presence of the living.</p>
-						<h4>Unique Strengths</h4>
-						<p>Upon entering the location, Thaye will become active, defensive and agile.</p>
-						<h4>Weaknesses</h4>
-						<p>Thaye will weaken over time, making them weaker, slower and less aggressive.</p>
-						<h4>Unique Features</h4>
-						<ul style="margin-left:15px">
-							<li><font color="orange">Average Sanity Hunt</font> starts at 75%. Decreases each time the ghost ages, stopping at 15%.</li>
-							<li><font color="tomato">Hunting Speed</font> increased by 60% at start. Decreases each time the ghost ages, stopping at 1/3 of the initial speed (slower than players).</li>
-							<li><font color="deepskyblue">Interactions</font> and <font color="aqua">Ghost Events</font> happen very frequently at start. Decreases each time the ghost ages, stopping at 1/4 of the initial frequency.</li>
-							<li>Does not speed up with line of sight of a player.</li>
-							<li>Only ages when a player is in the same room as the ghost.</li>
-						</ul>
-						<h4>Evidence</h4>
-					</div>
-					<ul class="evidence">
-						<li data-evidence="orb">Ghost Orb</li>
-						<li data-evidence="writing">Ghost Writing</li>
 						<li data-evidence="dots">D.O.T.S Projector</li>
 					</ul>
 				</div>

--- a/index.html
+++ b/index.html
@@ -417,7 +417,7 @@
 						<h4>Evidence</h4>
 					</div>
 					<ul class="evidence">
-						<li data-evidence="box">Spirit Box</li>
+						<li data-evidence="box" required="true">Spirit Box</li>
 						<li data-evidence="writing">Ghost Writing</li>
 						<li data-evidence="dots">D.O.T.S Projector</li>
 					</ul>
@@ -574,7 +574,7 @@
 						<h4>Evidence</h4>
 					</div>
 					<ul class="evidence">
-						<li data-evidence="box">Spirit Box</li>
+						<li data-evidence="box" required="true">Spirit Box</li>
 						<li data-evidence="freezing">Freezing Temperatures</li>
 						<li data-evidence="writing">Ghost Writing</li>
 					</ul>


### PR DESCRIPTION
All the ghosts are alphabetically ordered except these three newest ones. This makes the ordering consistent.

Also add the missing `required="true"` attributes to Deogen and Moroi while I'm at it.