### PR TITLE
Dark color scheme for scrollbar

### DIFF
--- a/main.css
+++ b/main.css
@@ -4,6 +4,10 @@
 	box-sizing: border-box;
 }
 
+:root {
+	color-scheme: dark;
+}
+
 body {
 	/*display: flex;*/
 	/*flex-direction: column;*/


### PR DESCRIPTION
Simply apply the standard dark color scheme, which makes the scrollbar dark. Fits the style of the website better.